### PR TITLE
Store event response token after confirmation

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -15,6 +15,7 @@
 - [ ] Notify organizer on cancel?
 - [ ] "Upgrade" from no RSVP to RSVP
 - [ ] Allow host to delete RSVPs
+  - [ ] Edge case: what if response edit token is in localstorage, but event owner has deleted the response?
 - [ ] Allow host to email attendees
 - [ ] Email attendees on changes
 - [ ] Email attendees on deletion
@@ -24,7 +25,6 @@
   - [ ] Why are hamburger items missing on Confirm RSVP page?
 - [ ] URL builder helpers
 - [ ] Form to request resend link(s) for email address
-- [ ] Hold RSVP locally with cookie
 - [ ] Resend confirmation if an RSVP enters an existing email
 - [ ] Add Sentry to frontend
 - [ ] Diff dates in `notify` so that they are omitted when unchanged
@@ -40,6 +40,7 @@
 - [ ] Make Sentry DSN optional
 - [ ] Consensually gather user emails for mailing list
 - [ ] Add pretty error messages for 404s (e.g. clicked an expired/tidied link)
+- [x] Hold RSVP locally with cookie
 - [x] **Scheduler engine**
   - [x] Send reminders
   - [x] Delete unconfirmed events

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "bulma-prefers-dark": "^0.1.0-beta.1",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
+    "jotai": "^2.10.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-select": "^5.8.2",

--- a/web/src/components/NewResponseForm/NewResponseForm.tsx
+++ b/web/src/components/NewResponseForm/NewResponseForm.tsx
@@ -7,6 +7,7 @@ import {
 } from 'types/graphql'
 
 import { useForm } from '@redwoodjs/forms'
+import { Link, routes } from '@redwoodjs/router'
 import { useMutation } from '@redwoodjs/web'
 
 import Typ from 'src/components/Typ/Typ'
@@ -15,6 +16,7 @@ import ResponseForm, { FormValues } from '../ResponseForm/ResponseForm'
 
 interface Props {
   event: Pick<PublicEvent, 'id' | 'title' | 'responseConfig'>
+  responseToken?: string
 }
 
 const CREATE_RESPONSE = gql`
@@ -28,9 +30,7 @@ const CREATE_RESPONSE = gql`
   }
 `
 
-const NewResponseForm = (props: Props) => {
-  const { event } = props
-
+const NewResponseForm = ({ event, responseToken }: Props) => {
   const formMethods = useForm<FormValues>({
     mode: 'onTouched',
     defaultValues: { headCount: 1 },
@@ -50,6 +50,21 @@ const NewResponseForm = (props: Props) => {
   if (event.responseConfig === 'DISABLED') return null
 
   const Title = <Typ x="subhead">RSVP to {event.title}</Typ>
+
+  if (responseToken) {
+    return (
+      <>
+        {Title}
+        <Typ x="p">You&apos;ve already submitted your RSVP for this event.</Typ>
+        <Link
+          to={routes.confirmResponse({ token: responseToken })}
+          className="button is-primary mt-2"
+        >
+          Edit my RSVP &raquo;
+        </Link>
+      </>
+    )
+  }
 
   if (createdForEmail) {
     return (

--- a/web/src/components/ResponseForm/ResponseForm.tsx
+++ b/web/src/components/ResponseForm/ResponseForm.tsx
@@ -74,10 +74,6 @@ const ResponseForm = (props: Props) => {
   return (
     <>
       <Typ x="p">{privacyNote}</Typ>
-      <Typ x="p">
-        <em>Making changes to your RSVP?</em> Use the link we sent to your email
-        to edit your details or cancel your RSVP.
-      </Typ>
 
       <Form
         className="mt-3"

--- a/web/src/data/atoms.ts
+++ b/web/src/data/atoms.ts
@@ -1,0 +1,9 @@
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+
+const storage = createJSONStorage<Record<string, string>>(() => localStorage)
+
+export const responseTokenAtom = atomWithStorage<Record<string, string>>(
+  `responseToken`,
+  {},
+  storage
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -18317,6 +18317,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jotai@npm:^2.10.2":
+  version: 2.10.2
+  resolution: "jotai@npm:2.10.2"
+  peerDependencies:
+    "@types/react": ">=17.0.0"
+    react: ">=17.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 4eb13ed91c669fea1df0daef1f50acb5c839772425d913dc3b03a392847a8d49e391934b18e9342743b0da1dcf92cf23c025af1c0860ff92d45f56544021d632
+  languageName: node
+  linkType: hard
+
 "js-beautify@npm:^1.14.11":
   version: 1.15.1
   resolution: "js-beautify@npm:1.15.1"
@@ -25778,6 +25793,7 @@ __metadata:
     bulma-prefers-dark: ^0.1.0-beta.1
     classnames: ^2.5.1
     dayjs: ^1.11.13
+    jotai: ^2.10.2
     postcss: ^8.4.47
     postcss-loader: ^8.1.1
     react: ^18.3.1


### PR DESCRIPTION
This allows a user to see that they've already responded on the event page and go straight to their existing response.