### PR TITLE
FIx use of OG image for event preview

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -40,6 +40,7 @@
 - [ ] Make Sentry DSN optional
 - [ ] Consensually gather user emails for mailing list
 - [ ] Add pretty error messages for 404s (e.g. clicked an expired/tidied link)
+- [ ] Redirect old slugs on slug change
 - [x] Hold RSVP locally with cookie
 - [x] **Scheduler engine**
   - [x] Send reminders

--- a/web/src/components/ShowEvent/ShowEvent.tsx
+++ b/web/src/components/ShowEvent/ShowEvent.tsx
@@ -9,6 +9,7 @@ import {
   prettyStartWithUntil,
 } from 'src/apiLib/convert/date'
 import { markdownToHTML } from 'src/apiLib/markdown'
+import { eventPreviewImagePublicURL } from 'src/apiLib/url'
 import { SITE_HOST } from 'src/app.config'
 import { responseTokenAtom } from 'src/data/atoms'
 import { scrollTo } from 'src/logic/scroll'
@@ -115,7 +116,11 @@ const ShowEvent = ({ event, preview }: Props) => {
       {preview ? (
         <Typ x="head">{event.title}</Typ>
       ) : (
-        <PageHead title={event.title} desc={event.description.slice(0, 80)} />
+        <PageHead
+          title={event.title}
+          desc={event.description.slice(0, 80)}
+          ogImage={eventPreviewImagePublicURL(event.slug)}
+        />
       )}
       <Typ x="p">
         <strong>From:</strong> {prettyStartWithUntil(start, tz)}


### PR DESCRIPTION
Changes to our metadata tags and `<PageHead>` elements caused us to lose the Open Graph preview image for event pages. This fixes that issue.