### PR TITLE
Global Unsubscribe

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/*SVG.tsx'],
+      files: ['**/*SVG.tsx', '**/*.test.ts', '**/*.test.tsx'],
       rules: {
         'max-len': 'off',
       },

--- a/NOTES.md
+++ b/NOTES.md
@@ -42,6 +42,8 @@
 - [ ] Site-wide announcement feature
 - [ ] Unify email templates (header, unsub footer, etc.)
 - [ ] Unify email and Discord notifications
+- [ ] "Serious mode" for LoadingBuddy for e.g. unsubscribe requests
+- [ ] Notification when target email is denylisted on record creation
 - [x] Captcha
 - [x] Hold RSVP locally with cookie
 - [x] **Scheduler engine**

--- a/NOTES.md
+++ b/NOTES.md
@@ -40,6 +40,8 @@
 - [ ] Add pretty error messages for 404s (e.g. clicked an expired/tidied link)
 - [ ] Redirect old slugs on slug change
 - [ ] Site-wide announcement feature
+- [ ] Unify email templates (header, unsub footer, etc.)
+- [ ] Unify email and Discord notifications
 - [x] Captcha
 - [x] Hold RSVP locally with cookie
 - [x] **Scheduler engine**

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example values are provided in [.env.example](.env.example). Make a copy of that
 | RECAPTCHA_SERVER_KEY             | string | yes       | [ReCAPTCHA](https://www.google.com/recaptcha) site key for the backend                                                                     |
 | REDWOOD_ENV_RECAPTCHA_CLIENT_KEY | string | yes       | [ReCAPTCHA](https://www.google.com/recaptcha) site key for the frontend                                                                    |
 | REDWOOD_ENV_SENTRY_ENV           | string |           | Custom name reported for the environment for frontend Sentry errors. If unset, defaults to `process.env.NODE_ENV`.                         |
+| SECRET_KEY                       | string | yes       | An opaque value used to sign data stored on a client                                                                                       |
 | SENTRY_DSN                       | string | yes       | DSN URL for your Sentry project, where errors are reported                                                                                 |
 | SITE_HOST                        | string | yes       | The hostname of your Freevite instance, used in absolute URLs (e.g. email content)                                                         |
 | SMTP_HOST                        | string | yes       | Hostname for your SMTP outgoing mail server                                                                                                |

--- a/api/db/migrations/20241120055143_add_ignored_emails/migration.sql
+++ b/api/db/migrations/20241120055143_add_ignored_emails/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "IgnoredEmail" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "email" TEXT NOT NULL,
+    CONSTRAINT "IgnoredEmail_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IgnoredEmail_email_key" ON "IgnoredEmail"("email");

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -76,3 +76,11 @@ model Reminder {
   sendAt DateTime
   sent   Boolean  @default(false)
 }
+
+model IgnoredEmail {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  email String @unique
+}

--- a/api/src/graphql/ignoredEmails.sdl.ts
+++ b/api/src/graphql/ignoredEmails.sdl.ts
@@ -1,0 +1,22 @@
+export const schema = gql`
+  type IgnoredEmail {
+    id: Int!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    email: String!
+  }
+
+  input IgnoredEmailInput {
+    email: String!
+    token: String!
+  }
+
+  type Query {
+    ignoredEmail(input: IgnoredEmailInput!): IgnoredEmail @requireAuth
+  }
+
+  type Mutation {
+    createIgnoredEmail(input: IgnoredEmailInput!): IgnoredEmail! @requireAuth
+    deleteIgnoredEmail(input: IgnoredEmailInput!): IgnoredEmail! @requireAuth
+  }
+`

--- a/api/src/graphql/responses.sdl.ts
+++ b/api/src/graphql/responses.sdl.ts
@@ -41,8 +41,6 @@ export const schema = gql`
   }
 
   type Query {
-    responses: [Response!]! @requireAuth
-    response(id: Int!): Response @requireAuth
     responseByEditToken(editToken: String!): UpdatableResponse @skipAuth
   }
 

--- a/api/src/lib/email/send.test.ts
+++ b/api/src/lib/email/send.test.ts
@@ -1,12 +1,17 @@
 import { InMemoryMailHandler } from '@redwoodjs/mailer-handler-in-memory'
 
+import { db } from '../db'
 import { mailer } from '../mailer'
 
 import { sendEmail } from './send'
 
 describe('mailer', () => {
+  const testHandler = mailer.getTestHandler() as InMemoryMailHandler
+  beforeEach(async () => {
+    await testHandler.clearInbox()
+  })
+
   it('sends an email', async () => {
-    const testHandler = mailer.getTestHandler() as InMemoryMailHandler
     expect(testHandler.inbox).toHaveLength(0)
 
     const params = {
@@ -41,5 +46,32 @@ https://example.com/unsubscribe?email=darlene%40fs0ciety.pizza&token=wgPFf2G9H7D
   ],
 }
 `)
+  })
+
+  describe('when users are on the ignore list', () => {
+    beforeEach(async () => {
+      await db.ignoredEmail.create({ data: { email: 'wh1ter0se@da.cn' } })
+    })
+    afterEach(async () => {
+      await db.ignoredEmail.deleteMany()
+    })
+
+    it('obeys the ignore list', async () => {
+      expect(testHandler.inbox).toHaveLength(0)
+      await sendEmail({
+        to: 'wh1ter0se@da.cn',
+        subject: "You're invited to End of the World Party",
+        text: 'Bring your own mask',
+      })
+      expect(testHandler.inbox).toHaveLength(0)
+
+      // but it still sends to other addresses
+      await sendEmail({
+        to: 'ealderson@ecorp.com',
+        subject: 'Looking for an update on the malware presentation',
+        text: 'Please send ASAP',
+      })
+      expect(testHandler.inbox).toHaveLength(1)
+    })
   })
 })

--- a/api/src/lib/email/send.test.ts
+++ b/api/src/lib/email/send.test.ts
@@ -40,7 +40,7 @@ describe('mailer', () => {
   "textContent": "Leave this email here
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=darlene%40fs0ciety.pizza&token=wgPFf2G9H7D9zKIEjop_AeZCED7pLZex619NqYasXwk",
+https://example.com/unsubscribe?email=darlene%40fs0ciety.pizza&token=U4_qTnHZg6tTAKBEdY8C_CxVQsqP12HtTqmhYQ05Ywc",
   "to": [
     "darlene@fs0ciety.pizza",
   ],

--- a/api/src/lib/email/send.test.ts
+++ b/api/src/lib/email/send.test.ts
@@ -27,12 +27,15 @@ describe('mailer', () => {
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Leave this email here",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
   "subject": "Don't delete me",
-  "textContent": "Leave this email here",
+  "textContent": "Leave this email here
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=darlene%40fs0ciety.pizza&token=wgPFf2G9H7D9zKIEjop_AeZCED7pLZex619NqYasXwk",
   "to": [
     "darlene@fs0ciety.pizza",
   ],

--- a/api/src/lib/email/send.ts
+++ b/api/src/lib/email/send.ts
@@ -4,6 +4,7 @@ import { mailer } from 'src/lib/mailer'
 import { logger } from '../logger'
 
 import { Plain } from './plain'
+import { unsubscribeFooter } from './unsubscribe'
 
 interface Params {
   to: string | string[]
@@ -16,10 +17,13 @@ interface Params {
  * @param params The email parameters
  * @returns The result of the send operation
  */
-export async function sendEmail({ subject, text, ...p }: Params) {
+export async function sendEmail({ subject, text: _text, ...p }: Params) {
+  const firstRecipient = Array.isArray(p.to) ? p.to[0] : p.to
+  const to = Array.isArray(p.to) ? p.to : [p.to]
+
+  const text = _text.trim() + '\n\n' + unsubscribeFooter(firstRecipient)
   const { name, email } = MAIL_SENDER
   const from = `"${name}" <${email}>`
-  const to = Array.isArray(p.to) ? p.to : [p.to]
   logger.info({ from, to, subject, text }, 'Sending email')
   return mailer.send(Plain({ text }), { subject, from, to })
 }

--- a/api/src/lib/email/send.ts
+++ b/api/src/lib/email/send.ts
@@ -1,6 +1,7 @@
 import { MAIL_SENDER } from 'src/api.config'
 import { mailer } from 'src/lib/mailer'
 
+import { db } from '../db'
 import { logger } from '../logger'
 
 import { Plain } from './plain'
@@ -18,12 +19,33 @@ interface Params {
  * @returns The result of the send operation
  */
 export async function sendEmail({ subject, text: _text, ...p }: Params) {
-  const firstRecipient = Array.isArray(p.to) ? p.to[0] : p.to
-  const to = Array.isArray(p.to) ? p.to : [p.to]
+  const unfilteredTo = Array.isArray(p.to) ? p.to : [p.to]
+  const to = await minusIgnored(unfilteredTo)
+  if (to.length === 0) return
 
+  const firstRecipient = Array.isArray(p.to) ? p.to[0] : p.to
   const text = _text.trim() + '\n\n' + unsubscribeFooter(firstRecipient)
   const { name, email } = MAIL_SENDER
   const from = `"${name}" <${email}>`
   logger.info({ from, to, subject, text }, 'Sending email')
   return mailer.send(Plain({ text }), { subject, from, to })
+}
+
+/** Filter a list of emails to remove recipients who have opted out of emails. */
+async function minusIgnored(to: string[]): Promise<string[]> {
+  const result = await db.ignoredEmail.findMany({
+    where: { email: { in: to } },
+    select: { email: true },
+  })
+  const ignored = result.map((x) => x.email).filter(Boolean) as string[]
+
+  if (ignored.length > 0) {
+    logger.info(
+      { emailsOnIgnoreList: ignored },
+      'Refusing to email user(s) on ignore list'
+    )
+  }
+
+  const allowed = to.filter((email) => !ignored.includes(email))
+  return allowed
 }

--- a/api/src/lib/email/template/event.test.ts
+++ b/api/src/lib/email/template/event.test.ts
@@ -48,7 +48,7 @@ If you did not create this event, you can ignore this email and this event will 
 If you need any help, just reply to this email. Thanks for using Freevite!
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
+https://example.com/unsubscribe?email=emma%40example.com&token=8RHP9HXHbkVfnYJ_6H5xSWGL6_5o6Er7aeoYW5SBGNg",
   "to": [
     "emma@example.com",
   ],

--- a/api/src/lib/email/template/event.test.ts
+++ b/api/src/lib/email/template/event.test.ts
@@ -31,7 +31,7 @@ describe('with test handler', () => {
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Hello from Freevite! Click this link to manage your event details and make it public:<br><br>https://example.com/edit?token=SOME-EDIT-TOKEN<br><br>You must click the above link within 24 hours to confirm your email address.<br>Otherwise, we will automatically delete your event. Feel free to recreate it.<br><br>If you did not create this event, you can ignore this email and this event will be deleted.<br><br>If you need any help, just reply to this email. Thanks for using Freevite!",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
@@ -45,7 +45,10 @@ Otherwise, we will automatically delete your event. Feel free to recreate it.
 
 If you did not create this event, you can ignore this email and this event will be deleted.
 
-If you need any help, just reply to this email. Thanks for using Freevite!",
+If you need any help, just reply to this email. Thanks for using Freevite!
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
   "to": [
     "emma@example.com",
   ],

--- a/api/src/lib/email/template/event.ts
+++ b/api/src/lib/email/template/event.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags'
 import { Event } from 'types/graphql'
 
-import { SITE_HOST } from 'src/app.config'
+import { SITE_URL } from 'src/app.config'
 
 import { sendEmail } from '../send'
 
@@ -19,7 +19,7 @@ export async function sendEventDetails(
     text: stripIndent`
 			Hello from Freevite! Click this link to manage your event details and make it public:
 
-			https://${SITE_HOST}/edit?token=${event.editToken}
+			${SITE_URL}/edit?token=${event.editToken}
 
 			You must click the above link within 24 hours to confirm your email address.
 			Otherwise, we will automatically delete your event. Feel free to recreate it.

--- a/api/src/lib/email/template/reminder.test.ts
+++ b/api/src/lib/email/template/reminder.test.ts
@@ -37,7 +37,7 @@ describe('with test handler', () => {
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Hello from Freevite! You asked for a reminder about this event when you RSVPed:<br><br>Emma&#39;s Holiday Party<br>Starts at: Sun Dec 25, 2022, 7:00 AM EST (in a day))<br>Ends at: Sun Dec 25, 2022, 10:00 AM EST (3 hours long)<br><br>View the event here:<br>https://example.com/events/emmas-holiday-party<br><br>Thanks for using Freevite!",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
@@ -51,7 +51,10 @@ Ends at: Sun Dec 25, 2022, 10:00 AM EST (3 hours long)
 View the event here:
 https://example.com/events/emmas-holiday-party
 
-Thanks for using Freevite!",
+Thanks for using Freevite!
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=holmes%40example.com&token=xZPATAWTt2b9dRKrUFJ9yE982ThnnvUg6APxtN_gr8s",
   "to": [
     "holmes@example.com",
   ],

--- a/api/src/lib/email/template/reminder.test.ts
+++ b/api/src/lib/email/template/reminder.test.ts
@@ -54,7 +54,7 @@ https://example.com/events/emmas-holiday-party
 Thanks for using Freevite!
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=holmes%40example.com&token=xZPATAWTt2b9dRKrUFJ9yE982ThnnvUg6APxtN_gr8s",
+https://example.com/unsubscribe?email=holmes%40example.com&token=gDd6UhfXCs8ipE9rs9JuUN5lwNUgSJjs6NXyZXdUgm4",
   "to": [
     "holmes@example.com",
   ],

--- a/api/src/lib/email/template/reminder.ts
+++ b/api/src/lib/email/template/reminder.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags'
 import { PublicEvent, Response } from 'types/graphql'
 
-import { SITE_HOST } from 'src/app.config'
+import { SITE_URL } from 'src/app.config'
 
 import {
   prettyEndWithBetween,
@@ -37,7 +37,7 @@ export async function sendReminder({
       Ends at: ${prettyEndWithBetween(event.start, event.end, event.timezone)}
 
       View the event here:
-      https://${SITE_HOST}/events/${event.slug}
+      ${SITE_URL}/events/${event.slug}
 
       Thanks for using Freevite!
     `,

--- a/api/src/lib/email/template/response.test.ts
+++ b/api/src/lib/email/template/response.test.ts
@@ -53,7 +53,7 @@ To change your response or delete your RSVP, click the link above.
 If you did not RSVP to this event, you can ignore this email.
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=holmes%40example.com&token=xZPATAWTt2b9dRKrUFJ9yE982ThnnvUg6APxtN_gr8s",
+https://example.com/unsubscribe?email=holmes%40example.com&token=gDd6UhfXCs8ipE9rs9JuUN5lwNUgSJjs6NXyZXdUgm4",
   "to": [
     "holmes@example.com",
   ],
@@ -103,7 +103,7 @@ https://example.com/edit?token=SOME-EDIT-TOKEN
 Thanks for using Freevite!
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
+https://example.com/unsubscribe?email=emma%40example.com&token=8RHP9HXHbkVfnYJ_6H5xSWGL6_5o6Er7aeoYW5SBGNg",
   "to": [
     "emma@example.com",
   ],
@@ -154,7 +154,7 @@ https://example.com/edit?token=SOME-EDIT-TOKEN
 Thanks for using Freevite!
 
 To unsubscribe from all Freevite emails forever, click here:
-https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
+https://example.com/unsubscribe?email=emma%40example.com&token=8RHP9HXHbkVfnYJ_6H5xSWGL6_5o6Er7aeoYW5SBGNg",
   "to": [
     "emma@example.com",
   ],

--- a/api/src/lib/email/template/response.test.ts
+++ b/api/src/lib/email/template/response.test.ts
@@ -37,7 +37,7 @@ describe('with test handler', () => {
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Hello from Freevite!<br><br>Click here to confirm you&#39;re attending Emma&#39;s Holiday Party:<br>https://example.com/rsvp?token=SOME-EDIT-TOKEN<br>Once you do, we&#39;ll confirm your RSVP and notify the event organizer.<br><br>To change your response or delete your RSVP, click the link above.<br><br>If you did not RSVP to this event, you can ignore this email.",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
@@ -50,7 +50,10 @@ Once you do, we'll confirm your RSVP and notify the event organizer.
 
 To change your response or delete your RSVP, click the link above.
 
-If you did not RSVP to this event, you can ignore this email.",
+If you did not RSVP to this event, you can ignore this email.
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=holmes%40example.com&token=xZPATAWTt2b9dRKrUFJ9yE982ThnnvUg6APxtN_gr8s",
   "to": [
     "holmes@example.com",
   ],
@@ -83,7 +86,7 @@ If you did not RSVP to this event, you can ignore this email.",
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Hello from Freevite! Sherlock Holmes has confirmed they are attending Emma&#39;s Holiday Party:<br><br>Name: Sherlock Holmes<br>Guests: 2<br>Comment: Looking forward to it!<br><br>To view all responses and manage your event, click here:<br>https://example.com/edit?token=SOME-EDIT-TOKEN<br><br>Thanks for using Freevite!",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
@@ -97,7 +100,10 @@ Comment: Looking forward to it!
 To view all responses and manage your event, click here:
 https://example.com/edit?token=SOME-EDIT-TOKEN
 
-Thanks for using Freevite!",
+Thanks for using Freevite!
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
   "to": [
     "emma@example.com",
   ],
@@ -130,7 +136,7 @@ Thanks for using Freevite!",
   "handler": "nodemailer",
   "handlerOptions": undefined,
   "headers": {},
-  "htmlContent": "Hello from Freevite! Sherlock Holmes has canceled their RSVP to Emma&#39;s Holiday Party.<br><br>Here are the details of the RSVP before it was canceled:<br>Name: Sherlock Holmes<br>Guests: 2<br>Comment: Looking forward to it!<br><br>To view all RSVPs and manage your event, click here:<br>https://example.com/edit?token=SOME-EDIT-TOKEN<br><br>Thanks for using Freevite!",
+  "htmlContent": null,
   "renderer": "plain",
   "rendererOptions": {},
   "replyTo": undefined,
@@ -145,7 +151,10 @@ Comment: Looking forward to it!
 To view all RSVPs and manage your event, click here:
 https://example.com/edit?token=SOME-EDIT-TOKEN
 
-Thanks for using Freevite!",
+Thanks for using Freevite!
+
+To unsubscribe from all Freevite emails forever, click here:
+https://example.com/unsubscribe?email=emma%40example.com&token=oyTyug8SP9wjzqGkAI7AKThdFp4hQs0bBLAPfq1SbRs",
   "to": [
     "emma@example.com",
   ],

--- a/api/src/lib/email/unsubscribe.test.ts
+++ b/api/src/lib/email/unsubscribe.test.ts
@@ -1,32 +1,22 @@
 import { unsubscribeFooter, unsubscribeLink } from './unsubscribe'
 
-describe('with a secret key set', () => {
-  const secretKey = 'secret-key-for-testing'
-  beforeEach(() => {
-    process.env.SECRET_KEY = secretKey
+describe('unsubscribeLink', () => {
+  it('builds the signed unsubscribe link for an email address', () => {
+    expect(unsubscribeLink('angela@ecorp.tk')).toEqual(
+      `https://example.com/unsubscribe?` +
+        `email=angela%40ecorp.tk&` +
+        `token=z0YHlLya22BB1T_zpvaVCjRMOClavI4w5OkX6T2uMHE`
+    )
   })
-  afterEach(() => {
-    delete process.env.SECRET_KEY
-  })
+})
 
-  describe('unsubscribeLink', () => {
-    it('builds the signed unsubscribe link for an email address', () => {
-      expect(unsubscribeLink('angela@ecorp.tk')).toEqual(
+describe('unsubscribeFooter', () => {
+  it('builds the footer with the signed unsubscribe link', () => {
+    expect(unsubscribeFooter('angela@ecorp.tk')).toEqual(
+      `To unsubscribe from all Freevite emails forever, click here:\n` +
         `https://example.com/unsubscribe?` +
-          `email=angela%40ecorp.tk&` +
-          `token=aqoOgTFC8FtmzJXxn7os8kWCbJRzz4Mr5ToXfOvfXsY`
-      )
-    })
-  })
-
-  describe('unsubscribeFooter', () => {
-    it('builds the footer with the signed unsubscribe link', () => {
-      expect(unsubscribeFooter('angela@ecorp.tk')).toEqual(
-        `To unsubscribe from all Freevite emails forever, click here:\n` +
-          `https://example.com/unsubscribe?` +
-          `email=angela%40ecorp.tk&` +
-          `token=aqoOgTFC8FtmzJXxn7os8kWCbJRzz4Mr5ToXfOvfXsY`
-      )
-    })
+        `email=angela%40ecorp.tk&` +
+        `token=z0YHlLya22BB1T_zpvaVCjRMOClavI4w5OkX6T2uMHE`
+    )
   })
 })

--- a/api/src/lib/email/unsubscribe.test.ts
+++ b/api/src/lib/email/unsubscribe.test.ts
@@ -1,0 +1,32 @@
+import { unsubscribeFooter, unsubscribeLink } from './unsubscribe'
+
+describe('with a secret key set', () => {
+  const secretKey = 'secret-key-for-testing'
+  beforeEach(() => {
+    process.env.SECRET_KEY = secretKey
+  })
+  afterEach(() => {
+    delete process.env.SECRET_KEY
+  })
+
+  describe('unsubscribeLink', () => {
+    it('builds the signed unsubscribe link for an email address', () => {
+      expect(unsubscribeLink('angela@ecorp.tk')).toEqual(
+        `https://example.com/unsubscribe?` +
+          `email=angela%40ecorp.tk&` +
+          `token=aqoOgTFC8FtmzJXxn7os8kWCbJRzz4Mr5ToXfOvfXsY`
+      )
+    })
+  })
+
+  describe('unsubscribeFooter', () => {
+    it('builds the footer with the signed unsubscribe link', () => {
+      expect(unsubscribeFooter('angela@ecorp.tk')).toEqual(
+        `To unsubscribe from all Freevite emails forever, click here:\n` +
+          `https://example.com/unsubscribe?` +
+          `email=angela%40ecorp.tk&` +
+          `token=aqoOgTFC8FtmzJXxn7os8kWCbJRzz4Mr5ToXfOvfXsY`
+      )
+    })
+  })
+})

--- a/api/src/lib/email/unsubscribe.ts
+++ b/api/src/lib/email/unsubscribe.ts
@@ -1,0 +1,17 @@
+import { SITE_URL } from 'src/app.config'
+
+import { sign } from '../sign'
+
+/** Build the signed unsubscribe link for an email address. */
+export function unsubscribeLink(email: string): string {
+  const token = sign(email)
+  return `${SITE_URL}/unsubscribe?email=${encodeURIComponent(email)}&token=${token}`
+}
+
+/** Build the unsubscribe footer for an email address. */
+export function unsubscribeFooter(email: string): string {
+  return (
+    `To unsubscribe from all Freevite emails forever, click here:\n` +
+    `${unsubscribeLink(email)}`
+  )
+}

--- a/api/src/lib/mailer.ts
+++ b/api/src/lib/mailer.ts
@@ -1,5 +1,4 @@
 import { render as reactEmailRender } from '@react-email/render'
-import escapeHTML from 'escape-html'
 
 import { Mailer } from '@redwoodjs/mailer-core'
 import { AbstractMailRenderer } from '@redwoodjs/mailer-core'
@@ -20,7 +19,7 @@ class PlainEmailRenderer extends AbstractMailRenderer {
     _utilities?: MailUtilities
   ): MailRenderedContent {
     const text = template.props.children
-    const html = escapeHTML(text).replace(/\n/g, '<br>')
+    const html = null
     return { text, html }
   }
 

--- a/api/src/lib/notify/event.ts
+++ b/api/src/lib/notify/event.ts
@@ -1,6 +1,6 @@
 import { Event } from 'types/graphql'
 
-import { SITE_HOST } from 'src/app.config'
+import { SITE_URL } from 'src/app.config'
 
 import { notify } from '../notify'
 
@@ -24,8 +24,8 @@ export async function notifyEventCreated(
   await notify(`New event created`, event.title, {
     email: event.ownerEmail,
     responseConfig: JSON.stringify(event.responseConfig),
-    view: `https://${SITE_HOST}/event/${event.slug}`,
-    edit: `https://${SITE_HOST}/edit?token=${event.editToken}`,
+    view: `${SITE_URL}/event/${event.slug}`,
+    edit: `${SITE_URL}/edit?token=${event.editToken}`,
   })
 }
 
@@ -41,7 +41,7 @@ export async function notifyEventUpdated(
 ) {
   await notify(`Event updated`, event.title, {
     ...diff,
-    view: `https://${SITE_HOST}/event/${event.slug}`,
-    edit: `https://${SITE_HOST}/edit?token=${event.editToken}`,
+    view: `${SITE_URL}/event/${event.slug}`,
+    edit: `${SITE_URL}/edit?token=${event.editToken}`,
   })
 }

--- a/api/src/lib/notify/response.ts
+++ b/api/src/lib/notify/response.ts
@@ -1,6 +1,6 @@
 import { Event, Response } from 'types/graphql'
 
-import { SITE_HOST } from 'src/app.config'
+import { SITE_URL } from 'src/app.config'
 
 import { notify } from '../notify'
 
@@ -17,7 +17,7 @@ export async function notifyNewResponse(
   await notify(`New response to ${event.title}`, response.name, {
     headCount: response.headCount,
     comment: response.comment,
-    view: `https://${SITE_HOST}/event/${event.slug}`,
+    view: `${SITE_URL}/event/${event.slug}`,
   })
 }
 
@@ -34,6 +34,6 @@ export async function notifyResponseDeleted(
   await notify(`Response deleted from ${event.title}`, response.name, {
     headCount: response.headCount,
     comment: response.comment,
-    view: `https://${SITE_HOST}/event/${event.slug}`,
+    view: `${SITE_URL}/event/${event.slug}`,
   })
 }

--- a/api/src/lib/sign.test.ts
+++ b/api/src/lib/sign.test.ts
@@ -1,0 +1,27 @@
+describe('sign', () => {
+  const data = 'some-test-data'
+  const secretKey = 'secret-key-for-testing'
+  const expectedSignature = 'jpP2ltofCWsaXDeZZhTybDKA1mLzgnLxmkOO_iGqoZM'
+
+  describe('with a secret key set', () => {
+    beforeAll(() => {
+      process.env.SECRET_KEY = secretKey
+    })
+    afterAll(() => {
+      delete process.env.SECRET_KEY
+    })
+
+    it('signs data', () => {
+      const { sign } = require('./sign')
+      const signature = sign(data)
+      expect(signature).toEqual(expectedSignature)
+    })
+
+    it('verifies signatures', () => {
+      const { sign, verify } = require('./sign')
+      expect(verify(data, expectedSignature)).toBe(true)
+      expect(verify(data, sign(data))).toBe(true)
+      expect(verify(data, 'invalid-signature')).toBe(false)
+    })
+  })
+})

--- a/api/src/lib/sign.test.ts
+++ b/api/src/lib/sign.test.ts
@@ -1,27 +1,17 @@
 describe('sign', () => {
   const data = 'some-test-data'
-  const secretKey = 'secret-key-for-testing'
   const expectedSignature = 'jpP2ltofCWsaXDeZZhTybDKA1mLzgnLxmkOO_iGqoZM'
 
-  describe('with a secret key set', () => {
-    beforeAll(() => {
-      process.env.SECRET_KEY = secretKey
-    })
-    afterAll(() => {
-      delete process.env.SECRET_KEY
-    })
+  it('signs data', () => {
+    const { sign } = require('./sign')
+    const signature = sign(data)
+    expect(signature).toEqual(expectedSignature)
+  })
 
-    it('signs data', () => {
-      const { sign } = require('./sign')
-      const signature = sign(data)
-      expect(signature).toEqual(expectedSignature)
-    })
-
-    it('verifies signatures', () => {
-      const { sign, verify } = require('./sign')
-      expect(verify(data, expectedSignature)).toBe(true)
-      expect(verify(data, sign(data))).toBe(true)
-      expect(verify(data, 'invalid-signature')).toBe(false)
-    })
+  it('verifies signatures', () => {
+    const { sign, verify } = require('./sign')
+    expect(verify(data, expectedSignature)).toBe(true)
+    expect(verify(data, sign(data))).toBe(true)
+    expect(verify(data, 'invalid-signature')).toBe(false)
   })
 })

--- a/api/src/lib/sign.ts
+++ b/api/src/lib/sign.ts
@@ -12,6 +12,7 @@ export function sign(data: string): string {
 
 /** Verify the validity of signed data. */
 export function verify(data: string, signature: string): boolean {
+  console.log(`Expected: ${sign(data)}`)
   return sign(data) === signature
 }
 

--- a/api/src/lib/sign.ts
+++ b/api/src/lib/sign.ts
@@ -1,6 +1,8 @@
 import * as crypto from 'crypto'
 
-import { SECRET_KEY } from 'src/app.config'
+import { CI, SECRET_KEY } from 'src/app.config'
+
+const SECRET_KEY_FOR_TESTING = 'secret-key-for-testing'
 
 /** Sign string data with the app's secret key and return a URL-safe signature. */
 export function sign(data: string): string {
@@ -12,11 +14,11 @@ export function sign(data: string): string {
 
 /** Verify the validity of signed data. */
 export function verify(data: string, signature: string): boolean {
-  console.log(`Expected: ${sign(data)}`)
   return sign(data) === signature
 }
 
 function verifySecretKey() {
+  if (CI) return SECRET_KEY_FOR_TESTING
   if (!SECRET_KEY || SECRET_KEY === '') {
     throw new Error('SECRET_KEY is required for signing/validation')
   }

--- a/api/src/lib/sign.ts
+++ b/api/src/lib/sign.ts
@@ -4,15 +4,14 @@ import { SECRET_KEY } from 'src/app.config'
 
 /** Sign string data with the app's secret key and return a URL-safe signature. */
 export function sign(data: string): string {
-  verifySecretKey()
-  const hmac = crypto.createHmac('sha256', SECRET_KEY)
+  const key = verifySecretKey()
+  const hmac = crypto.createHmac('sha256', key)
   hmac.update(data)
   return hmac.digest('base64url')
 }
 
 /** Verify the validity of signed data. */
 export function verify(data: string, signature: string): boolean {
-  verifySecretKey()
   return sign(data) === signature
 }
 
@@ -20,4 +19,5 @@ function verifySecretKey() {
   if (!SECRET_KEY || SECRET_KEY === '') {
     throw new Error('SECRET_KEY is required for signing/validation')
   }
+  return SECRET_KEY
 }

--- a/api/src/lib/sign.ts
+++ b/api/src/lib/sign.ts
@@ -1,0 +1,23 @@
+import * as crypto from 'crypto'
+
+import { SECRET_KEY } from 'src/app.config'
+
+/** Sign string data with the app's secret key and return a URL-safe signature. */
+export function sign(data: string): string {
+  verifySecretKey()
+  const hmac = crypto.createHmac('sha256', SECRET_KEY)
+  hmac.update(data)
+  return hmac.digest('base64url')
+}
+
+/** Verify the validity of signed data. */
+export function verify(data: string, signature: string): boolean {
+  verifySecretKey()
+  return sign(data) === signature
+}
+
+function verifySecretKey() {
+  if (!SECRET_KEY || SECRET_KEY === '') {
+    throw new Error('SECRET_KEY is required for signing/validation')
+  }
+}

--- a/api/src/services/ignoredEmails/ignoredEmails.test.ts
+++ b/api/src/services/ignoredEmails/ignoredEmails.test.ts
@@ -1,0 +1,108 @@
+import { db } from 'src/lib/db'
+import { sign } from 'src/lib/sign'
+
+import {
+  createIgnoredEmail,
+  deleteIgnoredEmail,
+  ignoredEmail,
+} from './ignoredEmails'
+
+describe('with a secret key set', () => {
+  const secretKey = 'secret-key-for-testing'
+  beforeEach(() => {
+    process.env.SECRET_KEY = secretKey
+  })
+  afterEach(() => {
+    delete process.env.SECRET_KEY
+  })
+
+  describe('with an email on the ignore list', () => {
+    const emailExist = 'joanna@wellick.nl'
+    const sigExist = sign(emailExist)
+    const emailNotExist = 'tyrell@wellick.se'
+    const sigNotExist = sign(emailNotExist)
+
+    beforeEach(async () => {
+      await db.ignoredEmail.create({ data: { email: emailExist } })
+    })
+    afterEach(async () => {
+      await db.ignoredEmail.deleteMany()
+    })
+
+    describe('ignoredEmail', () => {
+      it('returns an existing record', async () => {
+        const record = await ignoredEmail({
+          input: { email: emailExist, token: sigExist },
+        })
+        expect(record.email).toEqual(emailExist)
+      })
+
+      it('returns null for a non-existing record', async () => {
+        const record = await ignoredEmail({
+          input: { email: emailNotExist, token: sigNotExist },
+        })
+        expect(record).toBeNull()
+      })
+
+      it('fails for an invalid token', async () => {
+        await expect(
+          ignoredEmail({ input: { email: emailExist, token: 'invalid' } })
+        ).rejects.toThrow('Could not validate your request')
+      })
+    })
+
+    describe('createIgnoredEmail', () => {
+      it('adds a new email to the ignore list', async () => {
+        expect(await db.ignoredEmail.count()).toEqual(1)
+        const record = await createIgnoredEmail({
+          input: { email: emailNotExist, token: sigNotExist },
+        })
+        expect(record.email).toEqual(emailNotExist)
+        expect(await db.ignoredEmail.count()).toEqual(2)
+      })
+
+      it('does not add an existing email twice', async () => {
+        expect(await db.ignoredEmail.count()).toEqual(1)
+        const record = await createIgnoredEmail({
+          input: { email: emailExist, token: sigExist },
+        })
+        expect(record.email).toEqual(emailExist)
+        expect(await db.ignoredEmail.count()).toEqual(1)
+      })
+
+      it('fails for an invalid token', async () => {
+        await expect(
+          createIgnoredEmail({
+            input: { email: emailExist, token: 'invalid' },
+          })
+        ).rejects.toThrow('Could not validate your request')
+      })
+    })
+
+    describe('deleteIgnoredEmail', () => {
+      it('deletes an email from the ignore list', async () => {
+        expect(await db.ignoredEmail.count()).toEqual(1)
+        await deleteIgnoredEmail({
+          input: { email: emailExist, token: sigExist },
+        })
+        expect(await db.ignoredEmail.count()).toEqual(0)
+      })
+
+      it('does nothing for an email missing from the list', async () => {
+        expect(await db.ignoredEmail.count()).toEqual(1)
+        await deleteIgnoredEmail({
+          input: { email: emailNotExist, token: sigNotExist },
+        })
+        expect(await db.ignoredEmail.count()).toEqual(1)
+      })
+
+      it('fails for an invalid token', async () => {
+        await expect(
+          deleteIgnoredEmail({
+            input: { email: emailExist, token: 'invalid' },
+          })
+        ).rejects.toThrow('Could not validate your request')
+      })
+    })
+  })
+})

--- a/api/src/services/ignoredEmails/ignoredEmails.test.ts
+++ b/api/src/services/ignoredEmails/ignoredEmails.test.ts
@@ -7,102 +7,92 @@ import {
   ignoredEmail,
 } from './ignoredEmails'
 
-describe('with a secret key set', () => {
-  const secretKey = 'secret-key-for-testing'
-  beforeEach(() => {
-    process.env.SECRET_KEY = secretKey
+describe('with an email on the ignore list', () => {
+  const emailExist = 'joanna@wellick.nl'
+  const sigExist = sign(emailExist)
+  const emailNotExist = 'tyrell@wellick.se'
+  const sigNotExist = sign(emailNotExist)
+
+  beforeEach(async () => {
+    await db.ignoredEmail.create({ data: { email: emailExist } })
   })
-  afterEach(() => {
-    delete process.env.SECRET_KEY
+  afterEach(async () => {
+    await db.ignoredEmail.deleteMany()
   })
 
-  describe('with an email on the ignore list', () => {
-    const emailExist = 'joanna@wellick.nl'
-    const sigExist = sign(emailExist)
-    const emailNotExist = 'tyrell@wellick.se'
-    const sigNotExist = sign(emailNotExist)
-
-    beforeEach(async () => {
-      await db.ignoredEmail.create({ data: { email: emailExist } })
-    })
-    afterEach(async () => {
-      await db.ignoredEmail.deleteMany()
+  describe('ignoredEmail', () => {
+    it('returns an existing record', async () => {
+      const record = await ignoredEmail({
+        input: { email: emailExist, token: sigExist },
+      })
+      expect(record.email).toEqual(emailExist)
     })
 
-    describe('ignoredEmail', () => {
-      it('returns an existing record', async () => {
-        const record = await ignoredEmail({
-          input: { email: emailExist, token: sigExist },
-        })
-        expect(record.email).toEqual(emailExist)
+    it('returns null for a non-existing record', async () => {
+      const record = await ignoredEmail({
+        input: { email: emailNotExist, token: sigNotExist },
       })
-
-      it('returns null for a non-existing record', async () => {
-        const record = await ignoredEmail({
-          input: { email: emailNotExist, token: sigNotExist },
-        })
-        expect(record).toBeNull()
-      })
-
-      it('fails for an invalid token', async () => {
-        await expect(
-          ignoredEmail({ input: { email: emailExist, token: 'invalid' } })
-        ).rejects.toThrow('Could not validate your request')
-      })
+      expect(record).toBeNull()
     })
 
-    describe('createIgnoredEmail', () => {
-      it('adds a new email to the ignore list', async () => {
-        expect(await db.ignoredEmail.count()).toEqual(1)
-        const record = await createIgnoredEmail({
-          input: { email: emailNotExist, token: sigNotExist },
-        })
-        expect(record.email).toEqual(emailNotExist)
-        expect(await db.ignoredEmail.count()).toEqual(2)
-      })
+    it('fails for an invalid token', async () => {
+      await expect(
+        ignoredEmail({ input: { email: emailExist, token: 'invalid' } })
+      ).rejects.toThrow('Could not validate your request')
+    })
+  })
 
-      it('does not add an existing email twice', async () => {
-        expect(await db.ignoredEmail.count()).toEqual(1)
-        const record = await createIgnoredEmail({
-          input: { email: emailExist, token: sigExist },
-        })
-        expect(record.email).toEqual(emailExist)
-        expect(await db.ignoredEmail.count()).toEqual(1)
+  describe('createIgnoredEmail', () => {
+    it('adds a new email to the ignore list', async () => {
+      expect(await db.ignoredEmail.count()).toEqual(1)
+      const record = await createIgnoredEmail({
+        input: { email: emailNotExist, token: sigNotExist },
       })
-
-      it('fails for an invalid token', async () => {
-        await expect(
-          createIgnoredEmail({
-            input: { email: emailExist, token: 'invalid' },
-          })
-        ).rejects.toThrow('Could not validate your request')
-      })
+      expect(record.email).toEqual(emailNotExist)
+      expect(await db.ignoredEmail.count()).toEqual(2)
     })
 
-    describe('deleteIgnoredEmail', () => {
-      it('deletes an email from the ignore list', async () => {
-        expect(await db.ignoredEmail.count()).toEqual(1)
-        await deleteIgnoredEmail({
-          input: { email: emailExist, token: sigExist },
-        })
-        expect(await db.ignoredEmail.count()).toEqual(0)
+    it('does not add an existing email twice', async () => {
+      expect(await db.ignoredEmail.count()).toEqual(1)
+      const record = await createIgnoredEmail({
+        input: { email: emailExist, token: sigExist },
       })
+      expect(record.email).toEqual(emailExist)
+      expect(await db.ignoredEmail.count()).toEqual(1)
+    })
 
-      it('does nothing for an email missing from the list', async () => {
-        expect(await db.ignoredEmail.count()).toEqual(1)
-        await deleteIgnoredEmail({
-          input: { email: emailNotExist, token: sigNotExist },
+    it('fails for an invalid token', async () => {
+      await expect(
+        createIgnoredEmail({
+          input: { email: emailExist, token: 'invalid' },
         })
-        expect(await db.ignoredEmail.count()).toEqual(1)
-      })
+      ).rejects.toThrow('Could not validate your request')
+    })
+  })
 
-      it('fails for an invalid token', async () => {
-        await expect(
-          deleteIgnoredEmail({
-            input: { email: emailExist, token: 'invalid' },
-          })
-        ).rejects.toThrow('Could not validate your request')
+  describe('deleteIgnoredEmail', () => {
+    it('deletes an email from the ignore list', async () => {
+      expect(await db.ignoredEmail.count()).toEqual(1)
+      await deleteIgnoredEmail({
+        input: { email: emailExist, token: sigExist },
       })
+      expect(await db.ignoredEmail.count()).toEqual(0)
+    })
+
+    it('does nothing for an email missing from the list', async () => {
+      expect(await db.ignoredEmail.count()).toEqual(1)
+      await deleteIgnoredEmail({
+        input: { email: emailNotExist, token: sigNotExist },
+      })
+      expect(await db.ignoredEmail.count()).toEqual(1)
+    })
+
+    it('fails for an invalid token', async () => {
+      await expect(
+        deleteIgnoredEmail({
+          input: { email: emailExist, token: 'invalid' },
+        })
+      ).rejects.toThrow('Could not validate your request')
     })
   })
 })

--- a/api/src/services/ignoredEmails/ignoredEmails.ts
+++ b/api/src/services/ignoredEmails/ignoredEmails.ts
@@ -1,0 +1,31 @@
+import type { QueryResolvers, MutationResolvers } from 'types/graphql'
+
+import { RedwoodError } from '@redwoodjs/api'
+
+import { db } from 'src/lib/db'
+import { verify } from 'src/lib/sign'
+
+const ERROR_MSG = 'Could not validate your request'
+
+export const ignoredEmail: QueryResolvers['ignoredEmail'] = async ({
+  input: { email, token },
+}) => {
+  if (!verify(email, token)) throw new RedwoodError(ERROR_MSG)
+  return db.ignoredEmail.findUnique({ where: { email } })
+}
+
+export const createIgnoredEmail: MutationResolvers['createIgnoredEmail'] =
+  async ({ input: { email, token } }) => {
+    if (!verify(email, token)) throw new RedwoodError(ERROR_MSG)
+    const existing = await db.ignoredEmail.findUnique({ where: { email } })
+    if (existing) return existing
+    return db.ignoredEmail.create({ data: { email } })
+  }
+
+export const deleteIgnoredEmail: MutationResolvers['deleteIgnoredEmail'] =
+  async ({ input: { email, token } }) => {
+    if (!verify(email, token)) throw new RedwoodError(ERROR_MSG)
+    const existing = await db.ignoredEmail.findUnique({ where: { email } })
+    if (!existing) return null
+    return db.ignoredEmail.delete({ where: { email } })
+  }

--- a/api/src/services/responses/responses.test.ts
+++ b/api/src/services/responses/responses.test.ts
@@ -1,4 +1,3 @@
-import type { Response } from '@prisma/client'
 import duration from 'dayjs/plugin/duration'
 
 import { db } from 'src/lib/db'

--- a/api/src/services/responses/responses.test.ts
+++ b/api/src/services/responses/responses.test.ts
@@ -6,8 +6,6 @@ import { db } from 'src/lib/db'
 import dayjs from '../../lib/dayjs'
 
 import {
-  responses,
-  response,
   createResponse,
   updateResponse,
   deleteResponse,
@@ -19,18 +17,6 @@ import type { StandardScenario } from './responses.scenarios'
 dayjs.extend(duration)
 
 describe('responses', () => {
-  scenario('returns all responses', async (scenario: StandardScenario) => {
-    const result = await responses()
-
-    expect(result.length).toEqual(Object.keys(scenario.response).length)
-  })
-
-  scenario('returns a single response', async (scenario: StandardScenario) => {
-    const result = await response({ id: scenario.response.one.id })
-
-    expect(result).toEqual({ ...scenario.response.one, reminders: [] })
-  })
-
   scenario('creates a response', async (scenario: StandardScenario) => {
     const result = await createResponse({
       eventId: scenario.response.two.eventId,
@@ -76,9 +62,9 @@ describe('responses', () => {
   )
 
   scenario('updates a response', async (scenario: StandardScenario) => {
-    const original = (await response({
-      id: scenario.response.one.id,
-    })) as Response
+    const original = await db.response.findUniqueOrThrow({
+      where: { id: scenario.response.one.id },
+    })
     const result = await updateResponse({
       editToken: original.editToken,
       input: { headCount: 42 },
@@ -88,18 +74,20 @@ describe('responses', () => {
   })
 
   scenario('deletes a response', async (scenario: StandardScenario) => {
-    const original = (await deleteResponse({
+    const original = await deleteResponse({
       editToken: scenario.response.one.editToken,
-    })) as Response
-    const result = await response({ id: original.id })
+    })
+    const result = await db.response.findUnique({
+      where: { id: original.id },
+    })
 
     expect(result).toEqual(null)
   })
 
   scenario('adds a reminder', async (scenario: StandardScenario) => {
-    const original = (await response({
-      id: scenario.response.one.id,
-    })) as Response
+    const original = await db.response.findUniqueOrThrow({
+      where: { id: scenario.response.one.id },
+    })
     const result = await updateResponse({
       editToken: original.editToken,
       input: { remindPriorSec: dayjs.duration(1, 'day').asSeconds() },
@@ -113,9 +101,9 @@ describe('responses', () => {
   })
 
   scenario('deletes a reminder', async (scenario: StandardScenario) => {
-    const original = (await response({
-      id: scenario.response.one.id,
-    })) as Response
+    const original = await db.response.findUniqueOrThrow({
+      where: { id: scenario.response.one.id },
+    })
     const result = await updateResponse({
       editToken: original.editToken,
       input: { remindPriorSec: null },

--- a/api/src/services/responses/responses.ts
+++ b/api/src/services/responses/responses.ts
@@ -10,9 +10,9 @@ import { RedwoodError } from '@redwoodjs/api'
 import { validateCaptcha } from 'src/lib/captcha'
 import { db } from 'src/lib/db'
 import {
-  sendNewResponseReceived,
+  // sendNewResponseReceived,
   sendResponseConfirmation,
-  sendResponseDeleted,
+  // sendResponseDeleted,
 } from 'src/lib/email/template/response'
 import {
   notifyNewResponse,
@@ -67,7 +67,7 @@ export const responseByEditToken: QueryResolvers['responseByEditToken'] =
         include: { event: true },
       })
       const { event } = updated
-      await sendNewResponseReceived({ event: event, response: updated })
+      // await sendNewResponseReceived({ event: event, response: updated })
       await notifyNewResponse(event, updated)
 
       resp = await db.response.findUnique({
@@ -116,6 +116,7 @@ export const createResponse: MutationResolvers['createResponse'] = async ({
       reminders: { create: reminders },
     },
   })
+  // FIXME: Restore this when we re-enable notitfication settings
   await sendResponseConfirmation({ event, response })
   return response
 }
@@ -166,7 +167,8 @@ export const deleteResponse: MutationResolvers['deleteResponse'] = async ({
     include: { event: true },
   })
   const { event } = response
-  await sendResponseDeleted({ response, event })
+  // FIXME: Restore this when we re-enable notitfication settings
+  // await sendResponseDeleted({ response, event })
   await notifyResponseDeleted(event, response)
   return response
 }

--- a/api/src/services/responses/responses.ts
+++ b/api/src/services/responses/responses.ts
@@ -67,6 +67,7 @@ export const responseByEditToken: QueryResolvers['responseByEditToken'] =
         include: { event: true },
       })
       const { event } = updated
+      // FIXME: Restore this when we build granular notitfication settings
       // await sendNewResponseReceived({ event: event, response: updated })
       await notifyNewResponse(event, updated)
 
@@ -116,7 +117,6 @@ export const createResponse: MutationResolvers['createResponse'] = async ({
       reminders: { create: reminders },
     },
   })
-  // FIXME: Restore this when we re-enable notitfication settings
   await sendResponseConfirmation({ event, response })
   return response
 }
@@ -167,7 +167,7 @@ export const deleteResponse: MutationResolvers['deleteResponse'] = async ({
     include: { event: true },
   })
   const { event } = response
-  // FIXME: Restore this when we re-enable notitfication settings
+  // FIXME: Restore this when we build granular notitfication settings
   // await sendResponseDeleted({ response, event })
   await notifyResponseDeleted(event, response)
   return response

--- a/api/src/services/responses/responses.ts
+++ b/api/src/services/responses/responses.ts
@@ -53,14 +53,6 @@ export function pickRemindPriorSec(input: {
   return duration
 }
 
-export const responses: QueryResolvers['responses'] = () => {
-  return db.response.findMany({ include: { reminders: true } })
-}
-
-export const response: QueryResolvers['response'] = ({ id }) => {
-  return db.response.findUnique({ where: { id }, include: { reminders: true } })
-}
-
 export const responseByEditToken: QueryResolvers['responseByEditToken'] =
   async ({ editToken }) => {
     let resp = await db.response.findUnique({

--- a/app.config.ts
+++ b/app.config.ts
@@ -14,6 +14,8 @@ export let SITE_HOST = process.env.SITE_HOST
 if (context === 'deploy-preview' || context === 'branch-deploy')
   SITE_HOST = extractAfterHTTPS(process.env.DEPLOY_PRIME_URL)
 
+export const SECRET_KEY = process.env.SECRET_KEY
+
 const protocol = SITE_HOST?.startsWith('localhost') ? 'http' : 'https'
 export const SITE_URL = `${protocol}://${SITE_HOST}` as const
 

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -25,6 +25,7 @@ const Routes = () => {
         {/* Below routes are used in email templates and cannot be changed */}
         <Route path="/edit" page={EditEventPage} name="editEvent" />
         <Route path="/rsvp" page={ConfirmResponsePage} name="confirmResponse" />
+        <Route path="/unsubscribe" page={UnsubscribePage} name="unsubscribe" />
       </Set>
       <Route notfound page={NotFoundPage} prerender />
     </Router>

--- a/web/src/components/IgnoredEmailCell/IgnoredEmailCell.tsx
+++ b/web/src/components/IgnoredEmailCell/IgnoredEmailCell.tsx
@@ -1,0 +1,153 @@
+import type {
+  IgnoredEmailQuery,
+  ResubscribeMutation,
+  ResubscribeMutationVariables,
+  UnsubscribeMutation,
+  UnsubscribeMutationVariables,
+} from 'types/graphql'
+
+import { type CellFailureProps, useMutation } from '@redwoodjs/web'
+
+import { queryValue } from 'src/logic/path'
+
+import Typ from '../Typ/Typ'
+
+export const QUERY = gql`
+  query IgnoredEmailQuery($input: IgnoredEmailInput!) {
+    data: ignoredEmail(input: $input) {
+      email
+    }
+  }
+`
+
+export const UNSUBSCRIBE_MUTATION = gql`
+  mutation UnsubscribeMutation($input: IgnoredEmailInput!) {
+    createIgnoredEmail(input: $input) {
+      email
+    }
+  }
+`
+
+export const RESUBSCRIBE_MUTATION = gql`
+  mutation ResubscribeMutation($input: IgnoredEmailInput!) {
+    deleteIgnoredEmail(input: $input) {
+      email
+    }
+  }
+`
+
+const ShowError = ({ error }: { error: Error }) => (
+  <>
+    <Typ x="p" className="has-text-danger">
+      Error: {error.message}
+    </Typ>
+    <Typ x="p">
+      Sorry, we&apos;re having trouble fulfilling your unsubscribe request.
+      Please email{' '}
+      <a href="mailto:support@freevite.com">support@freevite.com</a> and we will
+      make sure you are permanently unsubscribed from our emails.
+    </Typ>
+  </>
+)
+
+const UnsubscribeForm = ({
+  email,
+  token,
+}: {
+  email: string
+  token: string
+}) => {
+  const [save, { loading, error }] = useMutation<
+    UnsubscribeMutation,
+    UnsubscribeMutationVariables
+  >(UNSUBSCRIBE_MUTATION, {
+    refetchQueries: ['IgnoredEmailQuery'],
+  })
+
+  if (error) return <ShowError error={error} />
+
+  return (
+    <>
+      <Typ x="p">
+        Emails to <strong>{email}</strong> are currently{' '}
+        <span className="has-text-weight-bold has-text-success">enabled.</span>
+      </Typ>
+      <Typ x="p">
+        You are about to unsubscribe from <strong>all</strong> Freevite emails.
+        After this, Freevite will not email you for <strong>any reason.</strong>{' '}
+        This will prevent you from creating an event or RSVPing to an event, as
+        we need to send you a confirmation link via email.
+      </Typ>
+      <Typ x="subhead">Unsubscribe</Typ>
+      <Typ x="p">
+        To confirm you want to unsubscribe, click the button below:
+      </Typ>
+      <button
+        className="button is-danger"
+        onClick={() => {
+          save({ variables: { input: { email, token } } })
+        }}
+      >
+        {loading ? 'Unsubscribing...' : 'Unsubscribe from all emails'}
+      </button>
+    </>
+  )
+}
+
+const ResubscribeForm = ({
+  email,
+  token,
+}: {
+  email: string
+  token: string
+}) => {
+  const [save, { loading, error }] = useMutation<
+    ResubscribeMutation,
+    ResubscribeMutationVariables
+  >(RESUBSCRIBE_MUTATION, {
+    refetchQueries: ['IgnoredEmailQuery'],
+  })
+
+  if (error) return <ShowError error={error} />
+
+  return (
+    <>
+      <Typ x="p">
+        Emails to <strong>{email}</strong> are currently{' '}
+        <span className="has-text-weight-bold has-text-danger">disabled.</span>
+      </Typ>
+      <Typ x="p">
+        Freevite will not email you for <strong>any reason.</strong> This will
+        prevent you from creating an event or RSVPing to an event, as we need to
+        send you a confirmation link via email.
+      </Typ>
+      <Typ x="subhead">Resubscribe</Typ>
+      <Typ x="p">
+        If you want to start receiving Freevite emails again, click the button
+        below:
+      </Typ>
+      <button
+        className="button is-success"
+        onClick={() => {
+          save({ variables: { input: { email, token } } })
+        }}
+      >
+        {loading ? 'Resubscribing...' : 'Start receiving emails again'}
+      </button>
+    </>
+  )
+}
+
+export const Loading = () => <div>Loading...</div>
+
+export const Failure = ({ error }: CellFailureProps<IgnoredEmailQuery>) => (
+  <ShowError error={error} />
+)
+
+export const Empty = () => (
+  <UnsubscribeForm email={queryValue('email')} token={queryValue('token')} />
+)
+
+export const Success = () => (
+  <ResubscribeForm email={queryValue('email')} token={queryValue('token')} />
+)

--- a/web/src/pages/UnsubscribePage/UnsubscribePage.tsx
+++ b/web/src/pages/UnsubscribePage/UnsubscribePage.tsx
@@ -1,0 +1,20 @@
+import IgnoredEmailCell from 'src/components/IgnoredEmailCell'
+import PageHead from 'src/components/PageHead/PageHead'
+import { queryValue } from 'src/logic/path'
+
+const UnsubscribePage = () => {
+  return (
+    <>
+      <PageHead
+        title="Manage Email Preferences"
+        desc="Configure how Freevite communicates with you."
+      />
+
+      <IgnoredEmailCell
+        input={{ email: queryValue('email'), token: queryValue('token') }}
+      />
+    </>
+  )
+}
+
+export default UnsubscribePage


### PR DESCRIPTION
Allow users to unsubscribe from the entire Freevite email system via email footer link.

- New IgnoredEmail table tracks users who have requested a global unsubscribe
- Sign unsubscribe links with secret key
- Every email includes unsubscribe footer
- No HTML email content; just send plain text due to issue with escaping `&` in query URLs
- Remove too-broad Response queries
- Replace misuse of SITE_HOST with SITE_URL to fix URL protocols