### PR TITLE
fix: make CI pass again

### DIFF
--- a/api/src/lib/backend/notification/template/reminder.test.ts
+++ b/api/src/lib/backend/notification/template/reminder.test.ts
@@ -50,7 +50,7 @@ Starts at: Sun Dec 25, 2022, 7:00 AM EST (in a day))
 Ends at: Sun Dec 25, 2022, 10:00 AM EST (3 hours long)
 
 View the event here:
-https://example.com/events/emmas-holiday-party
+https://example.com/event/emmas-holiday-party
 
 Thanks for using Freevite!
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "@types/marked": "^4.0.8",
     "@types/react-dom": "^18.3.0",
     "@types/sanitize-html": "^2.8.0",
+    "eslint": "^8.57.1",
     "eslint-plugin-jsdoc": "^50.6.11",
+    "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tsx": "^4.19.3"

--- a/web/src/components/NewResponseForm/NewResponseForm.tsx
+++ b/web/src/components/NewResponseForm/NewResponseForm.tsx
@@ -79,7 +79,7 @@ const NewResponseForm = ({ event, responseToken }: Props) => {
             <span className="annoying-noti-hands">👉 👉</span> Check your email!{' '}
             <span className="annoying-noti-hands">👈 👈</span>
           </div>
-          We'll confirm your RSVP when you click the link in the email.
+          We&apos;ll confirm your RSVP when you click the link in the email.
         </Typ>
         <style>
           {`

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,6 +6178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pkgr/core@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@pkgr/core@npm:0.2.9"
+  checksum: ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+  languageName: node
+  linkType: hard
+
 "@prisma/client@npm:5.20.0":
   version: 5.20.0
   resolution: "@prisma/client@npm:5.20.0"
@@ -15255,6 +15262,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^5.2.1":
+  version: 5.5.5
+  resolution: "eslint-plugin-prettier@npm:5.5.5"
+  dependencies:
+    prettier-linter-helpers: ^1.0.1
+    synckit: ^0.11.12
+  peerDependencies:
+    "@types/eslint": ">=8.0.0"
+    eslint: ">=8.0.0"
+    eslint-config-prettier: ">= 7.0.0 <10.0.0 || >=10.1.0"
+    prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    "@types/eslint":
+      optional: true
+    eslint-config-prettier:
+      optional: true
+  checksum: 091449b28c77ab2efbbf674e977181f2c8453d95a4df68218bddd87a4dfaa9ecc4eda60164e416f5986fb5d577e66e8d8e1e23d81e8555f8d735375598b03257
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:4.6.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
@@ -15340,7 +15367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:8.57.1":
+"eslint@npm:8.57.1, eslint@npm:^8.57.1":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
   dependencies:
@@ -21779,6 +21806,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-linter-helpers@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "prettier-linter-helpers@npm:1.0.1"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 91cea965681bc5f62c9d26bd3ca6358b81557261d4802e96ec1cf0acbd99d4b61632d53320cd2c3ec7d7f7805a81345644108a41ef46ddc9688e783a9ac792d1
+  languageName: node
+  linkType: hard
+
 "prettier-plugin-tailwindcss@npm:^0.6.11":
   version: 0.6.11
   resolution: "prettier-plugin-tailwindcss@npm:0.6.11"
@@ -23392,7 +23428,9 @@ __metadata:
     common-tags: ^1.8.2
     dayjs: ^1.11.13
     escape-html: ^1.0.3
+    eslint: ^8.57.1
     eslint-plugin-jsdoc: ^50.6.11
+    eslint-plugin-prettier: ^5.2.1
     marked: ^15.0.11
     pluralize: ^8.0.0
     prettier: ^3.5.3
@@ -24666,6 +24704,15 @@ __metadata:
   version: 2.0.17
   resolution: "synchronous-promise@npm:2.0.17"
   checksum: 1babe643d8417789ef6e5a2f3d4b8abcda2de236acd09bbe2c98f6be82c0a2c92ed21a6e4f934845fa8de18b1435a9cba1e8c3d945032e8a532f076224c024b1
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.11.12":
+  version: 0.11.12
+  resolution: "synckit@npm:0.11.12"
+  dependencies:
+    "@pkgr/core": ^0.2.9
+  checksum: cc4d446806688ae0d728ae7bb3f53176d065cf9536647fb85bdd721dcefbd7bf94874df6799ff61580f2b03a392659219b778a9254ad499f9a1f56c34787c235
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updated reminder test snapshot to use `/event/` URL path
- Added missing `eslint-plugin-prettier` dependency (required by @redwoodjs/eslint-config)
- Fixed unescaped apostrophe in NewResponseForm

## Details
The CI was failing due to:
1. Test snapshot had outdated `/events/` path instead of `/event/`
2. `eslint-plugin-prettier` was missing from devDependencies but required by Redwood's ESLint config
3. React lint error for unescaped apostrophe in NewResponseForm.tsx