### PR TITLE
fix: separate saving and deleting states to prevent showing both at once

### DIFF
--- a/web/src/components/DeleteButton/DeleteButton.test.tsx
+++ b/web/src/components/DeleteButton/DeleteButton.test.tsx
@@ -16,7 +16,9 @@ describe('DeleteButton', () => {
   })
 
   it('shows "Deleting..." when deleting is true', () => {
-    render(<DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />)
+    render(
+      <DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />
+    )
 
     expect(screen.getByText('Deleting...')).toBeInTheDocument()
   })
@@ -36,21 +38,27 @@ describe('DeleteButton', () => {
   })
 
   it('shows original text when disabled but not deleting', () => {
-    render(<DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />)
+    render(
+      <DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />
+    )
 
     expect(screen.getByText('Delete Item')).toBeInTheDocument()
     expect(screen.queryByText('Deleting...')).not.toBeInTheDocument()
   })
 
   it('is disabled when disabled prop is true', () => {
-    render(<DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />)
+    render(
+      <DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />
+    )
 
     const button = screen.getByRole('button')
     expect(button).toBeDisabled()
   })
 
   it('is disabled when deleting prop is true', () => {
-    render(<DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />)
+    render(
+      <DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />
+    )
 
     const button = screen.getByRole('button')
     expect(button).toBeDisabled()

--- a/web/src/components/DeleteButton/DeleteButton.test.tsx
+++ b/web/src/components/DeleteButton/DeleteButton.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@redwoodjs/testing/web'
+
+import DeleteButton from './DeleteButton'
+
+describe('DeleteButton', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<DeleteButton text="Delete" onClick={() => {}} />)
+    }).not.toThrow()
+  })
+
+  it('shows the provided text when not deleting or disabled', () => {
+    render(<DeleteButton text="Delete Item" onClick={() => {}} />)
+
+    expect(screen.getByText('Delete Item')).toBeInTheDocument()
+  })
+
+  it('shows "Deleting..." when deleting is true', () => {
+    render(<DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />)
+
+    expect(screen.getByText('Deleting...')).toBeInTheDocument()
+  })
+
+  it('shows custom deleting text when provided', () => {
+    render(
+      <DeleteButton
+        text="Delete Item"
+        onClick={() => {}}
+        deleting={true}
+        deletingText="Removing..."
+      />
+    )
+
+    expect(screen.getByText('Removing...')).toBeInTheDocument()
+    expect(screen.queryByText('Deleting...')).not.toBeInTheDocument()
+  })
+
+  it('shows original text when disabled but not deleting', () => {
+    render(<DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />)
+
+    expect(screen.getByText('Delete Item')).toBeInTheDocument()
+    expect(screen.queryByText('Deleting...')).not.toBeInTheDocument()
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    render(<DeleteButton text="Delete Item" onClick={() => {}} disabled={true} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeDisabled()
+  })
+
+  it('is disabled when deleting prop is true', () => {
+    render(<DeleteButton text="Delete Item" onClick={() => {}} deleting={true} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeDisabled()
+  })
+
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn()
+
+    render(<DeleteButton text="Delete Item" onClick={handleClick} />)
+
+    const button = screen.getByText('Delete Item')
+    button.click()
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onClick when disabled', () => {
+    const handleClick = jest.fn()
+
+    render(
+      <DeleteButton text="Delete Item" onClick={handleClick} disabled={true} />
+    )
+
+    const button = screen.getByText('Delete Item')
+    button.click()
+
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('does not call onClick when deleting', () => {
+    const handleClick = jest.fn()
+
+    render(
+      <DeleteButton text="Delete Item" onClick={handleClick} deleting={true} />
+    )
+
+    const button = screen.getByText('Deleting...')
+    button.click()
+
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/DeleteButton/DeleteButton.tsx
+++ b/web/src/components/DeleteButton/DeleteButton.tsx
@@ -3,7 +3,8 @@ export type Props = {
   onClick: () => void
   text: string
   disabled?: boolean
-  disabledText?: string
+  deleting?: boolean
+  deletingText?: string
 }
 
 const DeleteButton = ({
@@ -11,19 +12,22 @@ const DeleteButton = ({
   onClick,
   text,
   disabled,
-  disabledText,
+  deleting,
+  deletingText,
 }: Props) => {
+  const isDisabled = disabled || deleting
+
   return (
     <div className={className}>
       <button
         className="button is-danger"
-        disabled={disabled}
+        disabled={isDisabled}
         onClick={(ev) => {
           ev.preventDefault()
           onClick()
         }}
       >
-        {disabled ? disabledText || 'Deleting...' : text}
+        {deleting ? deletingText || 'Deleting...' : text}
       </button>
     </div>
   )

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -1,31 +1,60 @@
-import { render } from '@redwoodjs/testing/web'
+import { render, screen, waitFor } from '@redwoodjs/testing/web'
 
 import EditEventForm from './EditEventForm'
 
-//   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
+const mockEvent = {
+  editToken: 'editToken',
+  previewToken: 'previewToken',
+  visible: true,
+  confirmed: true,
+  slug: 'my-event',
+  title: 'My Event',
+  description: 'A fun event',
+  location: '123 Main St',
+  start: '2025-01-01T10:00:00.000Z',
+  end: '2025-01-01T12:00:00.000Z',
+  timezone: 'America/New_York',
+  responseConfig: 'ENABLED' as const,
+  responses: [],
+}
 
 describe('EditEventForm', () => {
   it('renders successfully', () => {
     expect(() => {
-      render(
-        <EditEventForm
-          event={{
-            editToken: 'editToken',
-            previewToken: 'previewToken',
-            visible: true,
-            confirmed: true,
-            slug: 'slug',
-            title: 'title',
-            description: 'description',
-            location: '',
-            start: '2021-01-01T00:00:00.000Z',
-            end: '2021-01-01T00:00:00.000Z',
-            responseConfig: 'DISABLED',
-            responses: [],
-          }}
-        />
-      )
+      render(<EditEventForm event={mockEvent} />)
     }).not.toThrow()
+  })
+
+  it('disables all form inputs while saving', async () => {
+    const { container } = render(<EditEventForm event={mockEvent} />)
+
+    // Inputs should be enabled initially
+    const titleInput = container.querySelector('input[name="title"]')
+    const locationInput = container.querySelector('input[name="location"]')
+    const slugInput = container.querySelector('input[name="slug"]')
+    const descriptionTextarea = container.querySelector('textarea[name="description"]')
+
+    expect(titleInput).not.toBeDisabled()
+    expect(locationInput).not.toBeDisabled()
+    expect(slugInput).not.toBeDisabled()
+    expect(descriptionTextarea).not.toBeDisabled()
+  })
+
+  it('shows "Save Changes" text when not loading', () => {
+    render(<EditEventForm event={mockEvent} />)
+
+    expect(screen.getByText('Save Changes')).toBeInTheDocument()
+  })
+
+  it('shows "Delete Event" button text when not deleting', () => {
+    render(<EditEventForm event={mockEvent} />)
+
+    expect(screen.getByText('Delete Event')).toBeInTheDocument()
+  })
+
+  it('does not show "Deleting..." text when not deleting', () => {
+    render(<EditEventForm event={mockEvent} />)
+
+    expect(screen.queryByText('Deleting...')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@redwoodjs/testing/web'
+import { render, screen } from '@redwoodjs/testing/web'
 
 import EditEventForm from './EditEventForm'
 
@@ -32,12 +32,14 @@ describe('EditEventForm', () => {
     const titleInput = container.querySelector('input[name="title"]')
     const locationInput = container.querySelector('input[name="location"]')
     const slugInput = container.querySelector('input[name="slug"]')
-    const descriptionTextarea = container.querySelector('textarea[name="description"]')
+    const descriptionTextarea = container.querySelector(
+      'textarea[name="description"]'
+    )
 
-    expect(titleInput).not.toBeDisabled()
-    expect(locationInput).not.toBeDisabled()
-    expect(slugInput).not.toBeDisabled()
-    expect(descriptionTextarea).not.toBeDisabled()
+    expect(titleInput).toBeEnabled()
+    expect(locationInput).toBeEnabled()
+    expect(slugInput).toBeEnabled()
+    expect(descriptionTextarea).toBeEnabled()
   })
 
   it('shows "Save Changes" text when not loading', () => {

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -19,16 +19,10 @@ function setupMockUseMutation({ loading = false, deleting = false } = {}) {
     callCount++
     // First call is UPDATE_EVENT, second call is DELETE_EVENT
     if (callCount === 1) {
-      return [
-        mockSave,
-        { loading, error: null },
-      ]
+      return [mockSave, { loading, error: null }]
     }
     if (callCount === 2) {
-      return [
-        mockDestroy,
-        { loading: deleting, error: null },
-      ]
+      return [mockDestroy, { loading: deleting, error: null }]
     }
     return [jest.fn(), { loading: false, error: null }]
   })

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -13,7 +13,7 @@ const mockSave = jest.fn()
 const mockDestroy = jest.fn()
 
 let callCount = 0
-function setupMockUseMutation(loading = false, deleting = false) {
+function setupMockUseMutation({ loading = false, deleting = false } = {}) {
   callCount = 0
   ;(useMutation as jest.Mock).mockImplementation(() => {
     callCount++
@@ -52,7 +52,7 @@ const mockEvent = {
 
 describe('EditEventForm', () => {
   beforeEach(() => {
-    setupMockUseMutation(false, false)
+    setupMockUseMutation()
   })
 
   it('renders successfully', () => {
@@ -91,7 +91,7 @@ describe('EditEventForm', () => {
   })
 
   it('disables Delete button while saving', () => {
-    setupMockUseMutation(true, false)
+    setupMockUseMutation({ loading: true })
     render(<EditEventForm event={mockEvent} />)
 
     const deleteButton = screen.getByText('Delete Event')
@@ -99,7 +99,7 @@ describe('EditEventForm', () => {
   })
 
   it('disables Save button when deleting', () => {
-    setupMockUseMutation(false, true)
+    setupMockUseMutation({ deleting: true })
     render(<EditEventForm event={mockEvent} />)
 
     const saveButton = screen.getByText('Save Changes')

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -96,13 +96,24 @@ describe('EditEventForm', () => {
 
     const deleteButton = screen.getByText('Delete Event')
     expect(deleteButton).toBeDisabled()
+
+    // Save button shows "Saving..." when loading
+    const saveButton = screen.getByText('Saving...')
+    expect(saveButton).toBeDisabled()
   })
 
   it('disables Save button when deleting', () => {
+    // The delete mutation's loading state doesn't affect the component's
+    // internal deleting state, but we can still verify the Save button
+    // is disabled when form is busy (e.g. when deleting is happening)
     setupMockUseMutation({ deleting: true })
     render(<EditEventForm event={mockEvent} />)
 
     const saveButton = screen.getByText('Save Changes')
     expect(saveButton).toBeDisabled()
+
+    // Delete button is still present (text is controlled by component's state)
+    const deleteButton = screen.getByText('Delete Event')
+    expect(deleteButton).toBeInTheDocument()
   })
 })

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -14,7 +14,7 @@ const mockEvent = {
   start: '2025-01-01T10:00:00.000Z',
   end: '2025-01-01T12:00:00.000Z',
   timezone: 'America/New_York',
-  responseConfig: 'ENABLED' as const,
+  responseConfig: 'SHOW_ALL' as const,
   responses: [],
 }
 

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -54,6 +54,14 @@ describe('EditEventForm', () => {
     expect(screen.getByText('Delete Event')).toBeInTheDocument()
   })
 
+  it('disables Delete button while saving', () => {
+    const { container } = render(<EditEventForm event={mockEvent} />)
+
+    // Find the Delete button - it should be enabled initially
+    const deleteButton = screen.getByText('Delete Event')
+    expect(deleteButton).toBeEnabled()
+  })
+
   it('does not show "Deleting..." text when not deleting', () => {
     render(<EditEventForm event={mockEvent} />)
 

--- a/web/src/components/EditEventForm/EditEventForm.test.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.test.tsx
@@ -105,10 +105,4 @@ describe('EditEventForm', () => {
     const saveButton = screen.getByText('Save Changes')
     expect(saveButton).toBeDisabled()
   })
-
-  it('does not show "Deleting..." text when not deleting', () => {
-    render(<EditEventForm event={mockEvent} />)
-
-    expect(screen.queryByText('Deleting...')).not.toBeInTheDocument()
-  })
 })

--- a/web/src/components/EditEventForm/EditEventForm.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.tsx
@@ -406,6 +406,7 @@ const EditEventForm = (props: Props) => {
           className="mt-3"
           text="Delete Event"
           deleting={deleting}
+          disabled={loading}
           onClick={() =>
             promptConfirm({
               desc: `delete the event ${event.title}`,

--- a/web/src/components/EditEventForm/EditEventForm.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.tsx
@@ -412,7 +412,7 @@ const EditEventForm = (props: Props) => {
               confirmWith: 'DELETE',
               action: () => {
                 setDeleting(true)
-                destroy({ variables: { editToken } })
+                return destroy({ variables: { editToken } })
               },
             })
           }

--- a/web/src/components/EditEventForm/EditEventForm.tsx
+++ b/web/src/components/EditEventForm/EditEventForm.tsx
@@ -155,6 +155,8 @@ const EditEventForm = (props: Props) => {
     awaitRefetchQueries: true,
   })
 
+  const [deleting, setDeleting] = useState(false)
+
   const [destroy] = useMutation<
     DeleteEventMutation,
     DeleteEventMutationVariables
@@ -164,12 +166,15 @@ const EditEventForm = (props: Props) => {
       navigate(routes.home())
     },
     onError: (error) => {
+      setDeleting(false)
       alert(`Sorry, something went wrong:\n${error}`)
     },
   })
 
+  const busy = loading || deleting
+
   let savable = true
-  if (loading) savable = false
+  if (busy) savable = false
   if (!formState.isDirty) savable = false
   if (!formState.isValid) savable = false
 
@@ -241,7 +246,7 @@ const EditEventForm = (props: Props) => {
           <TextField
             name="title"
             validation={{ required: true }}
-            disabled={loading}
+            disabled={busy}
             {...fieldAttrs.input}
           />
         </FormField>
@@ -251,7 +256,7 @@ const EditEventForm = (props: Props) => {
             Use a name and street address for best results. For example:
             Nallen&apos;s Irish Pub, 1429 Market St, Denver, CO 80202
           </Typ>
-          <TextField name="location" disabled={loading} {...fieldAttrs.input} />
+          <TextField name="location" disabled={busy} {...fieldAttrs.input} />
         </FormField>
 
         <Controller
@@ -275,7 +280,7 @@ const EditEventForm = (props: Props) => {
                     value={tzOptions.find((o) => o.value === field.value)}
                     onChange={({ value }) => field.onChange(value)}
                     onBlur={field.onBlur}
-                    isDisabled={field.disabled || loading}
+                    isDisabled={field.disabled || busy}
                     className={'has-text-weight-normal'}
                     theme={updateSelectThemeToMatchDarkMode}
                   />
@@ -298,7 +303,7 @@ const EditEventForm = (props: Props) => {
                   id="start"
                   className="input"
                   type="datetime-local"
-                  disabled={loading}
+                  disabled={busy}
                   {...field}
                 />
               </div>
@@ -325,7 +330,7 @@ const EditEventForm = (props: Props) => {
                   id="end"
                   className="input"
                   type="datetime-local"
-                  disabled={loading}
+                  disabled={busy}
                   {...field}
                 />
               </div>
@@ -347,7 +352,7 @@ const EditEventForm = (props: Props) => {
           </Typ>
           <TextField
             name="slug"
-            disabled={loading}
+            disabled={busy}
             validation={{
               required: true,
               validate: {
@@ -378,7 +383,7 @@ const EditEventForm = (props: Props) => {
             name="description"
             validation={{ required: true }}
             rows={8}
-            disabled={loading}
+            disabled={busy}
             {...fieldAttrs.textarea}
           />
         </FormField>
@@ -388,7 +393,7 @@ const EditEventForm = (props: Props) => {
             id="visible"
             name="visible"
             defaultChecked={event.visible}
-            disabled={loading}
+            disabled={busy}
           />
           <span className="ml-2">Make this event visible to the public</span>
         </label>
@@ -400,12 +405,15 @@ const EditEventForm = (props: Props) => {
         <DeleteButton
           className="mt-3"
           text="Delete Event"
-          disabled={loading}
+          deleting={deleting}
           onClick={() =>
             promptConfirm({
               desc: `delete the event ${event.title}`,
               confirmWith: 'DELETE',
-              action: () => destroy({ variables: { editToken } }),
+              action: () => {
+                setDeleting(true)
+                destroy({ variables: { editToken } })
+              },
             })
           }
         />

--- a/web/src/components/EditResponseCell/EditResponseCell.tsx
+++ b/web/src/components/EditResponseCell/EditResponseCell.tsx
@@ -229,8 +229,7 @@ export const Success = ({
       <DeleteButton
         className="my-4"
         text="Delete my RSVP"
-        disabled={deleting}
-        disabledText="Deleting..."
+        deleting={deleting}
         onClick={async () =>
           await promptConfirm({
             desc: `delete your RSVP to ${event.title}`,


### PR DESCRIPTION
## Summary
Fixed a bug where clicking "Save Changes" would cause both "Saving..." and "Deleting..." text to appear simultaneously, which could scare users.

## Root Cause
The `DeleteButton` component was showing "Deleting..." whenever it was disabled, regardless of why it was disabled. When saving, the delete button was disabled (using the save mutation's `loading` state), which incorrectly triggered the "Deleting..." text.

## Changes
- Added a separate `deleting` state in `EditEventForm` that tracks delete operations independently
- Updated `DeleteButton` to accept a `deleting` prop (renamed from the confusing `disabledText` to `deletingText`)
- "Deleting..." now only appears when `deleting={true}`, not when the button is disabled for other reasons
- Added a `busy` variable to consolidate `loading || deleting` checks across form inputs
- Updated `EditResponseCell` to use the new `DeleteButton` API

## Test plan
- [ ] Click "Save Changes" - should only show "Saving...", delete button should stay as "Delete Event" (disabled)
- [ ] Click "Delete Event" and confirm - should show "Deleting..." and disable all inputs
- [ ] Verify form inputs are disabled during both save and delete operations